### PR TITLE
Tomcat config template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.war
 *.gz
 *.tgz
+*.jar

--- a/roles/archiva/defaults/main.yml
+++ b/roles/archiva/defaults/main.yml
@@ -5,3 +5,15 @@ tomcat_url: "http://apache.arvixe.com/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-
 
 # At the time of release, this is a link to the latest version of archiva. You may need to update this link.
 archiva_url: "http://apache.cs.utah.edu/archiva/2.2.0/binaries/apache-archiva-2.2.0.war"
+
+# Note, technically this is a link to download jdk.. but it won't work for you.  you'll need to grab it manually for now. 
+jdk_url: "http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jdk-8u60-linux-x64.tar.gz"
+
+# Java Activation Framework (from search.maven.org aka: the central repository)
+jaf_url: "http://search.maven.org/remotecontent?filepath=eu/ocathain/javax/activation/activation/1.1.1/activation-1.1.1.jar"
+
+# java mail api 
+mailapi_url: "http://search.maven.org/remotecontent?filepath=com/sun/mail/mailapi/1.5.4/mailapi-1.5.4.jar"
+
+# derby
+derby_url: "http://search.maven.org/remotecontent?filepath=org/wisdom-framework/derby/10.11.1.1_2/derby-10.11.1.1_2.jar"

--- a/roles/archiva/tasks/main.yml
+++ b/roles/archiva/tasks/main.yml
@@ -1,14 +1,37 @@
 ---
 
-- name: "download archiva if we don't already have it in the files directory"
-  local_action: get_url url={{ archiva_url }} force=no dest=./archiva.war 
-  sudo: false
-  run_once: true
+# get
 
 - name: "download tomcat if we don't already have it in the files directory"
   sudo: false
   local_action: get_url url={{ tomcat_url }} force=no dest=./tomcat.tar.gz
   run_once: true
+
+- name: "download JDK if we don't already have it in the files directory"
+  sudo: false
+  local_action: get_url url={{ jdk_url }} force=no dest=./jdk.tar.gz
+
+- name: "download archiva if we don't already have it in the files directory"
+  local_action: get_url url={{ archiva_url }} force=no dest=./archiva.war 
+  sudo: false
+  run_once: true
+
+- name: "download java activation framework if we don't have it already in the files directory"
+  local_action: get_url url={{ jaf_url }} force=no dest=./activation.jar
+  sudo: false
+  run_once: true
+
+- name: "download java mail api if we don't have it already"
+  local_action: get_url url={{ mailapi_url }} force=no dest=./mailapi.jar
+  sudo: false
+  run_once: true
+
+- name: "download derby if we don't have it already"
+  local_action: get_url url={{ derby_url }} force=no dest=./derby.jar
+  sudo: false
+  run_once: true
+
+# extract
 
 - name: "extract tomcat to opt"
   unarchive: src=tomcat.tar.gz dest=/opt/ copy=yes creates=/opt/tomcat #this is a little misleading because the tomcat folder isn't created until the next play. 
@@ -23,9 +46,47 @@
   command: mv /opt/{{ tomcat_dir["stdout"] }} /opt/tomcat
   when: tomcat_extract["changed"]
 
+- name: "extract jdk to /usr"
+  unarchive: src=jdk.tar.gz dest=/usr/ copy=yes creates=/usr/java #similar to before, this is misleading because the java folder isn't created until the next play.
+  register: jdk_extract
+
+- name: "get name of newly extracted JDK"
+  shell: ls /usr |grep ^jdk
+  register: jdk_dir 
+
+- name: "link /usr/java to newly extracted java directory"
+  file: src={{ jdk_dir["stdout"] }} path=/usr/java state=link
+
 - name: "ensure directory structure for archiva exists"
   file: path=/opt/tomcat/archiva state=directory
 
 - name: "copy archiva war to target server"
   copy: src=./archiva.war dest=/opt/tomcat/archiva
 
+# config archiva
+
+- name: ensure existance and configuration of setenv.sh
+  lineinfile: line="export JAVA_HOME=/usr/java" dest=/opt/tomcat/bin/setenv.sh create=yes state=present
+
+- name: get verison of tomcat
+  shell: /opt/tomcat/bin/version.sh
+  register: tomcat_ver
+
+- debug: var={{ tomcat_ver["stdout"] }}
+#|regex_replace('Server number:  ([0-9]*)','') }}
+
+- name: "ensure existance of tomcathome/conf/Catalina/localhost directory"
+  file: path=/opt/tomcat/conf/Catalina/localhost state=directory
+
+#- name: "configure tomcat to run archiva"
+#  template: src=archiva.xml.j2 dest=/opt/tomcat/conf/Catalina/localhost/archiva.xml
+
+## TODO: in tomcat 6 the dest directory should be /opt/tomcat/lib instead
+- name: "copy over the mailapi.jar"
+  copy: src=./mailapi.jar dest=/opt/tomcat/common/lib/
+
+- name: "copy over the mailapi.jar"
+  copy: src=./derby.jar dest=/opt/tomcat/common/lib/
+
+- name: "copy over the mailapi.jar"
+  copy: src=./activation.jar dest=/opt/tomcat/common/lib/

--- a/roles/archiva/tasks/main.yml
+++ b/roles/archiva/tasks/main.yml
@@ -72,14 +72,11 @@
   shell: /opt/tomcat/bin/version.sh
   register: tomcat_ver
 
-- debug: var={{ tomcat_ver["stdout"] }}
-#|regex_replace('Server number:  ([0-9]*)','') }}
-
 - name: "ensure existance of tomcathome/conf/Catalina/localhost directory"
   file: path=/opt/tomcat/conf/Catalina/localhost state=directory
 
-#- name: "configure tomcat to run archiva"
-#  template: src=archiva.xml.j2 dest=/opt/tomcat/conf/Catalina/localhost/archiva.xml
+- name: "configure tomcat to run archiva"
+  template: src=archiva.xml.j2 dest=/opt/tomcat/conf/Catalina/localhost/archiva.xml
 
 ## TODO: in tomcat 6 the dest directory should be /opt/tomcat/lib instead
 - name: "copy over the mailapi.jar"

--- a/roles/archiva/templates/archiva.xml.j2
+++ b/roles/archiva/templates/archiva.xml.j2
@@ -1,0 +1,14 @@
+{% if {{ tomcat.version < 6 }} %} <?xml version="2.0" encoding="UTF-8"?> {% endif %}
+ <Context path="/archiva"
+          docBase="${catalina.home}/archiva/apache-archiva-1.1.war">
+
+ <Resource name="jdbc/users" auth="Container" type="javax.sql.DataSource"
+           username="sa"
+           password=""
+           driverClassName="org.apache.derby.jdbc.EmbeddedDriver"
+           url="jdbc:derby:/path/to/database/users;create=true" />
+
+ <Resource name="mail/Session" auth="Container"
+            type="javax.mail.Session"
+            mail.smtp.host="localhost"/>
+ </Context>

--- a/roles/archiva/templates/archiva.xml.j2
+++ b/roles/archiva/templates/archiva.xml.j2
@@ -1,4 +1,4 @@
-{% if {{ tomcat.version < 6 }} %} <?xml version="2.0" encoding="UTF-8"?> {% endif %}
+{% if tomcat_ver.stdout_lines[7][16] < 6 %} <?xml version="2.0" encoding="UTF-8"?> {% endif %}
  <Context path="/archiva"
           docBase="${catalina.home}/archiva/apache-archiva-1.1.war">
 

--- a/roles/os_prep/tasks/main.yml
+++ b/roles/os_prep/tasks/main.yml
@@ -3,5 +3,4 @@
   apt: package={{ item }} state=present
   with_items:
     - links
-    - apache2
     - vim

--- a/roles/provision/tasks/main.yml
+++ b/roles/provision/tasks/main.yml
@@ -22,6 +22,6 @@
   with_items: ec2.instances
 
 - name: Wait for SSH to come up
-  wait_for: host={{ item.public_ip }} port=22 delay=60 timeout=320 state=started
+  wait_for: host={{ item.public_ip }} port=22 delay=60 timeout=6000 state=started
   with_items: ec2.instances
 


### PR DESCRIPTION
tomcat configuration for archiva is currently accomplished with a j2 template. It works but there is a potential bug in how I'm testing the version of tomcat.  Note in the Jinga2 template the line:
{% if tomcat_ver.stdout_lines[7][16] < 6 %} <?xml version="2.0" encoding="UTF-8"?> {% endif %}
this line relies on the format of the built in tomcat version.sh format remaining stable.  I will need to figure out a better way to do this.
